### PR TITLE
Fixes on Victory Medal and World Collection Pikachu

### DIFF
--- a/cards/en/vm.json
+++ b/cards/en/vm.json
@@ -1,17 +1,17 @@
 [
   {
-    "id": "vc-s07",
+    "id": "vm-s07",
     "name": "Victory Medal",
     "supertype": "Trainer",
     "rules": "Flip 2 coins. If one of them is heads, draw a card. If both are heads, search your deck for any 1 card, put it into your hand, and shuffle your deck afterward.",
     "artist": "Takumi Akabane",
     "rarity": "Promo",
     "legalities": {
-      "unlimited": "Legal",
+      "unlimited": "Legal"
     },
     "images": {
-      "small": "https://images.pokemontcg.io/vc/s07.png",
-      "large": "https://images.pokemontcg.io/vc/s07_hires.png"
+      "small": "https://images.pokemontcg.io/vm/s07.png",
+      "large": "https://images.pokemontcg.io/vm/s07_hires.png"
     }
-  },
+  }
 ]

--- a/cards/en/wc.json
+++ b/cards/en/wc.json
@@ -55,11 +55,11 @@
       25
     ],
     "legalities": {
-      "unlimited": "Legal",
+      "unlimited": "Legal"
     },
     "images": {
       "small": "https://images.pokemontcg.io/wc/en.png",
       "large": "https://images.pokemontcg.io/wc/en_hires.png"
     }
-  },
+  }
 ]

--- a/sets/en.json
+++ b/sets/en.json
@@ -780,7 +780,7 @@
       "unlimited": "Legal"
     },
     "releaseDate": "2007/05/26",
-    "updatedAt": "2022/05/20 15:37:00",
+    "updatedAt": "2022/05/20 15:37:00"
   },
   {
     "id": "dp2",
@@ -1092,7 +1092,7 @@
       "unlimited": "Legal"
     },
     "releaseDate": "2010/07/08",
-    "updatedAt": "2022/05/20 15:37:00",
+    "updatedAt": "2022/05/20 15:37:00"
   },
   {
     "id": "hgss3",


### PR DESCRIPTION
I deleted a couple extra commas here and there, and changed every mention of the Victory Medal set from `vc` from `vm` (it was already `vm` in `sets/en.json`)